### PR TITLE
location distance configurable in miles or kilometers

### DIFF
--- a/config/schema/social_geolocation.settings.yml
+++ b/config/schema/social_geolocation.settings.yml
@@ -8,3 +8,6 @@ social_geolocation.settings:
     geolocation_provider:
       type: string
       label: 'The choice for which provider to use to store geolocation data'
+    unit_of_measurement:
+      type: string
+      label: 'Unit of measurement'

--- a/social_geolocation.install
+++ b/social_geolocation.install
@@ -60,6 +60,10 @@ function social_geolocation_install() {
   \Drupal::service('config.factory')->getEditable('social_geolocation.settings')
     ->set('geolocation_provider', 'openstreetmaps')->save();
 
+  // Default unit of measurement - Kilometers
+  \Drupal::service('config.factory')->getEditable('social_geolocation.settings')
+      ->set('unit_of_measurement', 'km')->save();
+
   // Update the correct provider.
   \Drupal::service('config.factory')->getEditable('geocoder.settings')
     ->set('plugins_options', [

--- a/social_geolocation.install
+++ b/social_geolocation.install
@@ -95,6 +95,15 @@ function social_geolocation_update_8003(&$sandbox) {
 }
 
 /**
+ * Set the default unit of measurement to kilometers.
+ */
+function social_geolocation_update_8004(&$sandbox) {
+  // Default unit of measurement - Kilometers.
+  \Drupal::service('config.factory')->getEditable('social_geolocation.settings')
+    ->set('unit_of_measurement', 'km')->save();
+}
+
+/**
  * Function to set default permissions.
  */
 function _social_geolocation_set_permissions() {

--- a/social_geolocation.links.menu.yml
+++ b/social_geolocation.links.menu.yml
@@ -1,0 +1,6 @@
+social_geolocation.settings:
+  title: 'Geolocation settings'
+  description: 'Settings for Social Geolocation.'
+  route_name: social_geolocation.settings
+  parent: social_core.admin.config.social
+  weight: 70

--- a/social_geolocation.module
+++ b/social_geolocation.module
@@ -49,7 +49,7 @@ function social_geolocation_form_views_exposed_form_alter(&$form, FormStateInter
   ];
   $form['location_details']['proximity'] = [
     '#type' => 'number',
-    '#title' => t("Distance ($unit_of_measurement)"),
+    '#title' => t('Distance @unitOfMeasurement', ['@unitOfMeasurement' => $unit_of_measurement]),
     '#description' => t('Recommended range from 10 to 1000.'),
     '#min' => 0,
     '#max' => 10000,

--- a/social_geolocation.module
+++ b/social_geolocation.module
@@ -40,6 +40,8 @@ function social_geolocation_form_views_exposed_form_alter(&$form, FormStateInter
     return;
   }
 
+  $unit_of_measurement = \Drupal::config('social_geolocation.settings')->get('unit_of_measurement');
+
   $form['location_details'] = [
     '#title' => t('Location range'),
     '#type' => 'details',
@@ -47,7 +49,7 @@ function social_geolocation_form_views_exposed_form_alter(&$form, FormStateInter
   ];
   $form['location_details']['proximity'] = [
     '#type' => 'number',
-    '#title' => t('Distance (km)'),
+    '#title' => t("Distance ($unit_of_measurement)"),
     '#description' => t('Recommended range from 10 to 1000.'),
     '#min' => 0,
     '#max' => 10000,
@@ -296,6 +298,11 @@ function social_geolocation_search_api_db_query_alter(SelectInterface $db_query,
     if (empty($args[$key])) {
       return;
     }
+  }
+
+  $unit_of_measurement = \Drupal::config('social_geolocation.settings')->get('unit_of_measurement');
+  if ($unit_of_measurement === 'mi') {
+    $args['proximity'] = $args['proximity'] * 1.609344;
   }
 
   $tables = $db_query->getTables();

--- a/social_geolocation.module
+++ b/social_geolocation.module
@@ -49,7 +49,7 @@ function social_geolocation_form_views_exposed_form_alter(&$form, FormStateInter
   ];
   $form['location_details']['proximity'] = [
     '#type' => 'number',
-    '#title' => t('Distance @unitOfMeasurement', ['@unitOfMeasurement' => $unit_of_measurement]),
+    '#title' => t('Distance (@unitOfMeasurement)', ['@unitOfMeasurement' => $unit_of_measurement]),
     '#description' => t('Recommended range from 10 to 1000.'),
     '#min' => 0,
     '#max' => 10000,

--- a/src/Form/SocialGeolocationSettings.php
+++ b/src/Form/SocialGeolocationSettings.php
@@ -43,6 +43,17 @@ class SocialGeolocationSettings extends ConfigFormBase {
       ],
     ];
 
+    $form['unit_of_measurement'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Unit of measurement'),
+      '#description' => $this->t('Select your unit of measurement.'),
+      '#default_value' => $config->get('unit_of_measurement'),
+      '#options' => [
+        'km' => 'Kilometers',
+        'mi' => 'Miles',
+      ],
+    ];
+
     $geoconfig = $this->configFactory()->getEditable('geolocation.settings');
     $form['geolocation_google_map_api_key'] = [
       '#type' => 'textfield',
@@ -67,6 +78,7 @@ class SocialGeolocationSettings extends ConfigFormBase {
 
     $this->config('social_geolocation.settings')
       ->set('geolocation_provider', $form_state->getValue('geolocation_provider'))
+      ->set('unit_of_measurement', $form_state->getValue('unit_of_measurement'))
       ->save();
 
     // If users chooses Geolocation to be Google API we need to ensure


### PR DESCRIPTION
It adds Unit of measurement options (km or mi) to the configuration screen:
path: /admin/config/opensocial/social-geolocation