### PR TITLE
by robertragas: change postal code check to === because we are not ad…

### DIFF
--- a/src/Plugin/Geocoder/Preprocessor/Address.php
+++ b/src/Plugin/Geocoder/Preprocessor/Address.php
@@ -38,7 +38,7 @@ class Address extends PreprocessorBase {
       // For canada we need to remove postal code from the Address lookup.
       // See https://github.com/openstreetmap/Nominatim/issues/1052.
       // Canada has issues with postal codes and returning correct lat lng data.
-      if ($value['country_code'] !== NULL && $value['country_code'] !== 'CA') {
+      if ($value['country_code'] !== NULL && $value['country_code'] === 'CA') {
         unset($value['postal_code']);
       }
 


### PR DESCRIPTION
…ding but unsetting it otherwise it will be unset for every country.

Work in progress, still trying to fix that the faulty code gets saved to the database because now canada will not save postal code for events/profiles, not only when geocoding.

**Problem:**
The geolocation code has an exception for removing postal codes from the lookup for canada to get better results. Because of the code refactor some statements have changed by unsetting the postal code instead of adding, which needs that the condition get inverted also, but hasn't been done. This now removes postal codes from every country except Canada.

**Solution:**
Invert the condition
