### PR TITLE
Fix coding standards issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ supported.
 
 ### Supported Geocoding plugins
 #### OpenStreetMap
-By default this module uses the OpenStreetMap API. It is not needed to enter an API key. 
+By default this module uses the OpenStreetMap API. It is not needed to enter an 
+API key. 
 
 You can find the usage policy here:
 https://wiki.openstreetmap.org/wiki/API_usage_policy

--- a/README.md
+++ b/README.md
@@ -1,14 +1,39 @@
+# Social Geolocation
+
+## INTRODUCTION
 This module provides the ability to convert address field values into a set of
 coordinates that are stored with the entity. This enables the content to be 
 found in search based on location.
 
-## OpenStreetMap
+## REQUIREMENTS
+- `commerceguys/addressing:^1.0.0`
+- `drupal/address:^1.0`
+- `drupal/core:^8.x`
+- `drupal/geocoder:~2.0`
+- `drupal/geolocation": 2-dev`
+- `drupal/search_api_location:^1.0`
+- `drupal/social:>6.0`
+
+## INSTALLATION
+Please use composer to install this module with its requirements.
+
+Once installed you can use `drush` or the Drupal extensions page to enable this 
+module. You must enable at least one supported geolocation geocoding plugin.
+
+## CONFIGURATION
+This module allows you to select which geocoding plugin should be used and 
+specify a Google Maps API key if that geocoder is selected. See 
+"Supported Geocoding plugins" below for an overview of which plugins are 
+supported.
+
+### Supported Geocoding plugins
+#### OpenStreetMap
 By default this module uses the OpenStreetMap API. It is not needed to enter an API key. 
 
 You can find the usage policy here:
 https://wiki.openstreetmap.org/wiki/API_usage_policy
 
-## Google Maps API Key
+#### Google Maps API Key
 Optionally you can use the Google Maps API to transform address strings into 
 lattitude/longtitude pairs. For all server side requests no Google Maps API
 key is needed, however, rate limiting may apply. For the client side requests
@@ -17,11 +42,3 @@ be entered on the geolocation's configuration page.
 
 You can generate a key here:
 https://console.cloud.google.com/google/maps-apis/api-list?project=social-local-171213&organizationId=841499249988
-
-## Configuring your own Address fields to store geolocation data
-You can simply enable the `field_ui` module
-
-See step "Geocoding results from Address field": 
-https://www.drupal.org/docs/8/modules/geolocation-field/configuring-integration-between-geolocation-and-address-field
-
-And it should store your Address data in geolocation fields as well. 

--- a/assets/js/social_geolocation_autocomplete.js
+++ b/assets/js/social_geolocation_autocomplete.js
@@ -1,17 +1,15 @@
 (function ($) {
-    'use strict';
+  'use strict';
 
   Drupal.behaviors.socialGeolocationAutocomplete = {
     attach: function (context, settings) {
       $("input[name='geolocation_geocoder_google_geocoding_api']").change(function () {
-        if ($('.geolocation-geocoder-google-geocoding-api-state').val() == 0) {
+        if (!$('.geolocation-geocoder-google-geocoding-api-state').val()) {
           if ($('#ui-id-1 .ui-menu-item-wrapper').first().html() && $('#ui-id-1 .ui-menu-item-wrapper').first().html().length > 0) {
             $('#ui-id-1 .ui-menu-item-wrapper').first().click();
           }
         }
       });
     }
-  }
+  };
 })(jQuery);
-
-

--- a/modules/social_geolocation_maps/social_geolocation_maps.info.yml
+++ b/modules/social_geolocation_maps/social_geolocation_maps.info.yml
@@ -3,7 +3,7 @@ description: 'Provides Map providers for showing Social Geolocation data in View
 type: module
 core: 8.x
 dependencies:
-  - social_geolocation
   - geolocation:geolocation_leaflet
-  - social_event
+  - social:social_event
+  - social_geolocation:social_geolocation
 package: Social

--- a/modules/social_geolocation_maps/social_geolocation_maps.module
+++ b/modules/social_geolocation_maps/social_geolocation_maps.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * The Social Geolocation Maps module.
+ * Contains hook implementations for the Social Geolocation module.
  */
 
 use Drupal\Core\Form\FormStateInterface;
@@ -72,7 +72,7 @@ function social_geolocation_maps_views_query_alter(ViewExecutable $view, QueryPl
 }
 
 /**
- * implements hook_page_attachments_alter.
+ * Implements hook_page_attachments_alter().
  */
 function social_geolocation_maps_page_attachments_alter(array &$attachments) {
   $route_name = \Drupal::routeMatch()->getRouteName();

--- a/modules/social_geolocation_maps/social_geolocation_maps.module
+++ b/modules/social_geolocation_maps/social_geolocation_maps.module
@@ -10,6 +10,17 @@ use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
 
 /**
+ * Implements hook_help().
+ */
+function social_geolocation_maps_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'help.page.social_geolocation_maps':
+      return 'This module provides a Map on the events page. Enable the module and create an event with an address so it shows up on the map.';
+  }
+  return NULL;
+}
+
+/**
  * Implements hook_field_widget_form_alter().
  */
 function social_geolocation_maps_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {

--- a/modules/social_geolocation_maps/social_geolocation_maps.module
+++ b/modules/social_geolocation_maps/social_geolocation_maps.module
@@ -6,13 +6,14 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_help().
  */
-function social_geolocation_maps_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match) {
+function social_geolocation_maps_help($route_name, RouteMatchInterface $route_match) {
   switch ($route_name) {
     case 'help.page.social_geolocation_maps':
       return 'This module provides a Map on the events page. Enable the module and create an event with an address so it shows up on the map.';

--- a/modules/social_geolocation_search/social_geolocation_search.install
+++ b/modules/social_geolocation_search/social_geolocation_search.install
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * Installation hook implementations for the Social Geolocation Search module.
+ */
+
 use Drupal\search_api\Entity\Index;
 
 /**

--- a/modules/social_geolocation_search/social_geolocation_search.install
+++ b/modules/social_geolocation_search/social_geolocation_search.install
@@ -20,7 +20,7 @@ function social_geolocation_search_install() {
 
   // Ensure that configuration overrides are properly applied to the indexes.
   // Also see social_tagging.install.
-  foreach ($indexes as $index_id => $index) {
+  foreach ($indexes as $index) {
     // Simply saving the index will trigger a reprocessing of all fields.
     $index->save();
   }

--- a/modules/social_geolocation_search/social_geolocation_search.module
+++ b/modules/social_geolocation_search/social_geolocation_search.module
@@ -14,6 +14,17 @@ define('MI_TO_KM', 1.609344);
 define('EARTH_RADIUS', 6371);
 
 /**
+ * Implements hook_help().
+ */
+function social_geolocation_search_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'help.page.social_geolocation_search':
+      return 'This module allows you to find events, groups and users by location in search. It works with a SQL and SOLR back-end.';
+  }
+  return NULL;
+}
+
+/**
  * Retrieves the arguments for the search views.
  *
  * All returned values are normalised to kilometers.

--- a/modules/social_geolocation_search/social_geolocation_search.module
+++ b/modules/social_geolocation_search/social_geolocation_search.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Contains hook implementations for the Social Geolocation Search module.
@@ -7,6 +8,7 @@
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Database\Query\SelectInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\group\Entity\GroupType;
 use Drupal\search_api\Plugin\views\query\SearchApiQuery;
 use Drupal\search_api\Query\QueryInterface;
@@ -20,7 +22,7 @@ define('SOCIAL_GEOLOCATION_SEARCH_EARTH_RADIUS', 6371);
 /**
  * Implements hook_help().
  */
-function social_geolocation_search_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match) {
+function social_geolocation_search_help($route_name, RouteMatchInterface $route_match) {
   switch ($route_name) {
     case 'help.page.social_geolocation_search':
       return 'This module allows you to find events, groups and users by location in search. It works with a SQL and SOLR back-end.';
@@ -180,7 +182,7 @@ function social_geolocation_search_api_db_query_alter(SelectInterface $db_query,
     $entity_types = [$entity_types[$index]];
   }
 
-  // Add a complex snippet
+  // Add a complex snippet.
   foreach ($entity_types as $id => $entity_type) {
     if ($id) {
       $snippet .= ') OR (';

--- a/modules/social_geolocation_search/social_geolocation_search.module
+++ b/modules/social_geolocation_search/social_geolocation_search.module
@@ -1,4 +1,8 @@
 <?php
+/**
+ * @file
+ * Contains hook implementations for the Social Geolocation Search module.
+ */
 
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Database\Query\SelectInterface;
@@ -8,10 +12,10 @@ use Drupal\search_api\Plugin\views\query\SearchApiQuery;
 use Drupal\search_api\Query\QueryInterface;
 
 // The factor that is used to convert miles to kilometers.
-define('MI_TO_KM', 1.609344);
+define('SOCIAL_GEOLOCATION_SEARCH_MI_TO_KM', 1.609344);
 
 // The radius of the earth in kilometers.
-define('EARTH_RADIUS', 6371);
+define('SOCIAL_GEOLOCATION_SEARCH_EARTH_RADIUS', 6371);
 
 /**
  * Implements hook_help().
@@ -51,7 +55,7 @@ function _social_geolocation_search_get_proximity_arguments() {
   // Check whether we use miles or kilometers for our proximity.
   $unit_of_measurement = \Drupal::config('social_geolocation.settings')->get('unit_of_measurement');
   if ($unit_of_measurement === 'mi') {
-    $values['proximity'] *= MI_TO_KM;
+    $values['proximity'] *= SOCIAL_GEOLOCATION_SEARCH_MI_TO_KM;
   }
 
   return $values;
@@ -73,7 +77,7 @@ function social_geolocation_search_api_db_query_alter(SelectInterface $db_query,
     return;
   }
 
-  // Get the tables affected by this query
+  // Get the tables affected by this query.
   $tables = $db_query->getTables();
   $index = $query->getIndex()->id();
   $table = 'search_api_db_' . $index;
@@ -117,7 +121,8 @@ function social_geolocation_search_api_db_query_alter(SelectInterface $db_query,
     }
 
     if ($index === 'social_all') {
-      // Field specifying the index' data source (e.g. entity:group, entity:profile, etc.)
+      // Field specifying the index' data source (e.g. entity:group,
+      // entity:profile, etc.)
       $source_field = $alias . '.search_api_datasource';
       $entity_type = 'entity:group';
 
@@ -197,7 +202,7 @@ function social_geolocation_search_api_db_query_alter(SelectInterface $db_query,
     ':filter_latcos' => cos(deg2rad($args['proximity-lat'])),
     ':filter_lng' => deg2rad($args['proximity-lng']),
     ':filter_latsin' => sin(deg2rad($args['proximity-lat'])),
-    ':earth_radius' => EARTH_RADIUS,
+    ':earth_radius' => SOCIAL_GEOLOCATION_SEARCH_EARTH_RADIUS,
     ':proximity' => $args['proximity'],
   ]);
 }
@@ -241,15 +246,14 @@ function _social_geolocation_search_alter_solr_query(SearchApiQuery $query) {
   $location_options[] = [
     // The field as known to our backend.
     'field' => "${entity_type}_geolocation",
-    // The search latitude and longitude
+    // The search latitude and longitude.
     'lat' => $args['proximity-lat'],
     'lon' => $args['proximity-lng'],
-    // The search radius
+    // The search radius.
     'radius' => $args['proximity'],
   ];
   $query->setOption('search_api_location', $location_options);
 }
-
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -278,16 +282,15 @@ function social_geolocation_search_form_views_exposed_form_alter(&$form, FormSta
   // the user is searching for events specifically as other node types don't
   // have location data at this moment.
   if (isset($form['location_details']) && in_array($form['#id'], ['views-exposed-form-search-content-page', 'views-exposed-form-search-content-page-no-value'], TRUE)) {
-      $form['location_details']['#states'] = [
-        'visible' => [
-          ':input[name=type]' => [
-            'value' => 'event',
-          ],
+    $form['location_details']['#states'] = [
+      'visible' => [
+        ':input[name=type]' => [
+          'value' => 'event',
         ],
-      ];
+      ],
+    ];
   }
 }
-
 
 /**
  * Implements hook_block_view_BASE_BLOCK_ID_alter().

--- a/modules/social_geolocation_search/social_geolocation_search.views_execution.inc
+++ b/modules/social_geolocation_search/social_geolocation_search.views_execution.inc
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * Views alter hook implementations for the Social Geolocation Search module.
+ */
+
 use Drupal\search_api\Plugin\views\query\SearchApiQuery;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;

--- a/modules/social_geolocation_search/src/SocialGeolocationSearchApiConfigOverride.php
+++ b/modules/social_geolocation_search/src/SocialGeolocationSearchApiConfigOverride.php
@@ -7,7 +7,6 @@ use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Serialization\Yaml;
 
 /**
  * Config override sapi social_all social_content social_groups social_users.

--- a/social_geolocation.info.yml
+++ b/social_geolocation.info.yml
@@ -7,7 +7,7 @@ dependencies:
   - geolocation:geolocation
   - geolocation:geolocation_address
   - geolocation:geolocation_leaflet
-  - social_event
-  - social_group
-  - social_profile
+  - social:social_event
+  - social:social_group
+  - social:social_profile
 package: Social

--- a/social_geolocation.install
+++ b/social_geolocation.install
@@ -6,8 +6,6 @@
  */
 
 use Drupal\user\Entity\Role;
-use Drupal\search_api\Entity\Index;
-use Drupal\user\Entity\User;
 
 /**
  * Implements hook_install().

--- a/social_geolocation.module
+++ b/social_geolocation.module
@@ -17,6 +17,28 @@ use Drupal\user\Entity\User;
 // @todo Add update hook to convert settings to new keys.
 
 /**
+ * Implements hook_help().
+ */
+function social_geolocation_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'help.page.social_geolocation':
+      $text = file_get_contents(__DIR__ . '/README.md');
+      if (!\Drupal::moduleHandler()->moduleExists('markdown')) {
+        return '<pre>' . Html::escape($text) . '</pre>';
+      }
+      else {
+        // Use the Markdown filter to render the README.
+        $filter_manager = \Drupal::service('plugin.manager.filter');
+        $settings = \Drupal::configFactory()->get('markdown.settings')->getRawData();
+        $config = ['settings' => $settings];
+        $filter = $filter_manager->createInstance('markdown', $config);
+        return $filter->process($text, 'en');
+      }
+  }
+  return NULL;
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  *
  * Enhance the Views exposed filter blocks forms on the people overview.

--- a/social_geolocation.module
+++ b/social_geolocation.module
@@ -3,23 +3,24 @@
 /**
  * @file
  * Contains hook implementations for the Social Geolocation module.
+ *
+ * @todo Add update hook to convert settings to new keys.
  */
 
 use Drupal\address\AddressInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Link;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\node\NodeInterface;
 use Drupal\profile\Entity\ProfileInterface;
 use Drupal\user\Entity\User;
 
-// @todo Add update hook to convert settings to new keys.
-
 /**
  * Implements hook_help().
  */
-function social_geolocation_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match) {
+function social_geolocation_help($route_name, RouteMatchInterface $route_match) {
   switch ($route_name) {
     case 'help.page.social_geolocation':
       $text = file_get_contents(__DIR__ . '/README.md');
@@ -82,7 +83,7 @@ function social_geolocation_form_views_exposed_form_alter(&$form, FormStateInter
  *   What Form API element should be used for the container of the proximity
  *   filter, either 'details' or 'fieldset'.
  */
-function social_geolocation_attach_views_location_filter(&$form, $container_type = 'details') {
+function social_geolocation_attach_views_location_filter(array &$form, $container_type = 'details') {
   $geocoder_plugin = _social_geolocation_get_geocoder();
 
   if (empty($geocoder_plugin)) {

--- a/social_geolocation.module
+++ b/social_geolocation.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * The Social Geolocation module.
+ * Contains hook implementations for the Social Geolocation module.
  */
 
 use Drupal\address\AddressInterface;
@@ -76,7 +76,7 @@ function social_geolocation_form_views_exposed_form_alter(&$form, FormStateInter
 /**
  * Alters the form to attach the proximity filter.
  *
- * @param $form
+ * @param array $form
  *   The form to alter.
  * @param string $container_type
  *   What Form API element should be used for the container of the proximity
@@ -318,7 +318,7 @@ function _social_geolocation_entity_presave(FieldableEntityInterface $entity, $t
 /**
  * Retrieves the configured Geocoder plugin.
  *
- * @return \Drupal\geolocation\GeocoderInterface|FALSE
+ * @return \Drupal\geolocation\GeocoderInterface|false
  *   Returns the configured geocoder or false if none is configured or the
  *   configured geocoder could not be loaded.
  */
@@ -332,10 +332,11 @@ function _social_geolocation_get_geocoder() {
     $geocoder_plugin = \Drupal::service('plugin.manager.geolocation.geocoder')
       ->getGeocoder(
         $geocoder_plugin_id,
-        // The configuration object passed to the plugins is not actually used by
-        // the geocoders implemented in the Geolocation module. Configuration
-        // happens through configuration objects that are loaded directly from the
-        // config factory (e.g. see Drupal\geolocation_google_maps\Plugin\geolocation\Geocoder\GoogleGeocodingAPI::geocode()).
+        // The configuration object passed to the plugins is not actually used
+        // by the geocoders implemented in the Geolocation module. Configuration
+        // happens through configuration objects that are loaded directly from
+        // the config factory (e.g. see
+        // Drupal\geolocation_google_maps\Plugin\geolocation\Geocoder\GoogleGeocodingAPI::geocode()).
         []
       );
   }
@@ -425,13 +426,15 @@ function _social_geolocation_address_to_string(AddressInterface $address) : stri
 function _social_geolocation_reformat_address_for_api(AddressInterface $address) : array {
   $geocoder = _social_geolocation_get_geocoder();
   if ($geocoder !== FALSE && $geocoder->getPluginId() === 'nominatim') {
-    switch($address->getCountryCode()) {
-      // Nominatim doesn't handle postal codes for Canada well. See Issue #3086891.
+    switch ($address->getCountryCode()) {
+      // Nominatim doesn't handle postal codes for Canada well.
+      // See Issue #3086891.
       // To resolve this we remove the postal code before lookup.
       case 'CA':
         $postal_code = $address->get('postal_code')->getValue();
         $address->set('postal_code', '');
         return ['postal_code' => $postal_code];
+
       // Nominatim doesn't handle spaces in the postalcode for the Netherlands.
       // To resolve this any spaces are removed.
       case 'NL':

--- a/src/Form/SocialGeolocationSettings.php
+++ b/src/Form/SocialGeolocationSettings.php
@@ -2,8 +2,11 @@
 
 namespace Drupal\social_geolocation\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 // Defines the plugin name for the OpenStreetMap geocoder plugin.
 define('OPENSTREETMAP_PLUGIN_ID', 'nominatim');
@@ -15,6 +18,31 @@ define('GOOGLE_GEOCODER_API_PLUGIN_ID', 'google_geocoding_api');
  * Class SocialGeolocationSettings.
  */
 class SocialGeolocationSettings extends ConfigFormBase {
+
+  /**
+   * The Drupal module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $module_handler) {
+    parent::__construct($config_factory);
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('module_handler')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -65,14 +93,14 @@ class SocialGeolocationSettings extends ConfigFormBase {
 
     // Add the nominatim provider from OpenStreetMap if the geolocation_leaflet
     // module that contains the geocoder is enabled.
-    if (\Drupal::moduleHandler()->moduleExists('geolocation_leaflet')) {
+    if ($this->moduleHandler->moduleExists('geolocation_leaflet')) {
       // The label is intentionally not translatable because it's a brand name.
       $form['geolocation_provider']['#options'][OPENSTREETMAP_PLUGIN_ID] = 'OpenStreetMap';
     }
 
     // Add the Google Geocoder API if the geolocation_google_maps module that
     // contains the geocoder is enabled.
-    if (\Drupal::moduleHandler()->moduleExists('geolocation_google_maps')) {
+    if ($this->moduleHandler->moduleExists('geolocation_google_maps')) {
       // The label is intentionally not translatable because it's a brand name.
       $form['geolocation_provider']['#options'][GOOGLE_GEOCODER_API_PLUGIN_ID] = 'Google Geocoding API';
 


### PR DESCRIPTION
<h2>Problem</h2>

In order to get security coverage we need to adhere to coding standards.

<h2>Solution</h2>
Fix the coding standards flagged by the PAReview tool.

<h2>How to test</h2>

- [ ] Check that the module still works. 
- [ ] Verify that the warnings on the new PAReview are safe to ignore: https://pareview.sh/pareview/https-git.drupal.org-project-social_geolocation.git-bugfix-pareview
