### PR TITLE
DS-6965 - Performance improvements: Landing Page

### DIFF
--- a/modules/social_geolocation_search/src/SocialGeolocationSearchApiConfigOverride.php
+++ b/modules/social_geolocation_search/src/SocialGeolocationSearchApiConfigOverride.php
@@ -158,9 +158,7 @@ class SocialGeolocationSearchApiConfigOverride implements ConfigFactoryOverrideI
    * {@inheritdoc}
    */
   public function getCacheableMetadata($name) {
-    // This configuration override is invalidated if the enabled modules
-    // are changed.
-    return (new CacheableMetadata())->addCacheTags(['config:core.extension']);
+    return new CacheableMetadata();
   }
 
   /**


### PR DESCRIPTION
### Problem

After investigating performance issues on streams and landing pages we noticed the config override cachable metadata caused a big performance hit. 

### Solution

Make sure we don't add the config core extension to all the overrides. 
