### PR TITLE
Issue #3124038 by bramtenhove: Add a toggle to (temporarily) disable geocoding on entity actions

### DIFF
--- a/config/install/social_geolocation.settings.yml
+++ b/config/install/social_geolocation.settings.yml
@@ -1,2 +1,3 @@
+enabled: true
 geolocation_provider: nominatim
 unit_of_measurement: km

--- a/config/schema/social_geolocation.settings.yml
+++ b/config/schema/social_geolocation.settings.yml
@@ -2,6 +2,9 @@ social_geolocation.settings:
   type: config_object
   label: 'Social Geolocation settings'
   mapping:
+    enabled:
+      type: boolean
+      label: 'Whether entities are processed and geolocation happen'
     site_manager_assist:
       type: boolean
       label: 'Whether the user should be shown a message to contact a site manager in case of a geolocation error'

--- a/social_geolocation.install
+++ b/social_geolocation.install
@@ -30,6 +30,14 @@ function social_geolocation_update_8004(&$sandbox) {
 }
 
 /**
+ * Set the geocoding to enabled by default.
+ */
+function social_geolocation_update_8005(&$sandbox) {
+  \Drupal::service('config.factory')->getEditable('social_geolocation.settings')
+    ->set('enabled', TRUE)->save();
+}
+
+/**
  * Function to set default permissions.
  */
 function _social_geolocation_set_permissions() {

--- a/social_geolocation.module
+++ b/social_geolocation.module
@@ -234,6 +234,12 @@ function social_geolocation_profile_presave(ProfileInterface $profile) {
  *   The type of the entity being saved.
  */
 function _social_geolocation_entity_presave(FieldableEntityInterface $entity, $type) {
+  $enabled = \Drupal::config('social_geolocation.settings')->get('enabled');
+
+  if (!$enabled) {
+    return;
+  }
+
   $field_address = "field_{$type}_address";
   $field_geolocation = "field_{$type}_geolocation";
 

--- a/src/Form/SocialGeolocationSettings.php
+++ b/src/Form/SocialGeolocationSettings.php
@@ -68,6 +68,13 @@ class SocialGeolocationSettings extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('social_geolocation.settings');
 
+    $form['enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Geolocation enabled'),
+      '#description' => $this->t('Whether addresses will be geocoded or not.'),
+      '#default_value' => $config->get('enabled'),
+    ];
+
     $form['geolocation_provider'] = [
       '#type' => 'radios',
       '#title' => $this->t('Provider to use for storing Geolocation data'),
@@ -141,6 +148,7 @@ class SocialGeolocationSettings extends ConfigFormBase {
     parent::submitForm($form, $form_state);
 
     $this->config('social_geolocation.settings')
+      ->set('enabled', $form_state->getValue('enabled'))
       ->set('geolocation_provider', $form_state->getValue('geolocation_provider'))
       ->set('unit_of_measurement', $form_state->getValue('unit_of_measurement'))
       ->save();


### PR DESCRIPTION
# Problem
There are use cases where active geocoding on entity inserts or updates is unwanted.

One of them is when you perform a migration with already known geocoordinates. You don't want the geocoding to happen because you already have the info.

# Solution
Add a toggle option in the settings form which disables geocoding.

# Issue tracker
https://www.drupal.org/project/social_geolocation/issues/3124038