### PR TITLE
Issue #3154252 by navneet0693: Added support for flexible and secret groups.

### DIFF
--- a/config/optional/field.field.group.flexible_group.field_group_geolocation.yml
+++ b/config/optional/field.field.group.flexible_group.field_group_geolocation.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_group_geolocation
+    - group.type.flexible_group
+  module:
+    - geolocation
+    - social_group
+    - social_group_flexible_group
+  enforced:
+    module:
+    - social_geolocation
+id: group.flexible_group.field_group_geolocation
+field_name: field_group_geolocation
+entity_type: group
+bundle: flexible_group
+label: Geolocation
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geolocation

--- a/config/optional/field.field.group.secret_group.field_group_geolocation.yml
+++ b/config/optional/field.field.group.secret_group.field_group_geolocation.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_group_geolocation
+    - group.type.secret_group
+  module:
+    - geolocation
+    - social_group
+    - social_group_secret
+  enforced:
+    module:
+    - social_geolocation
+id: group.secret_group.field_group_geolocation
+field_name: field_group_geolocation
+entity_type: group
+bundle: secret_group
+label: Geolocation
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geolocation

--- a/social_geolocation.install
+++ b/social_geolocation.install
@@ -5,6 +5,7 @@
  * Install, update and uninstall functions for the social_geolocation module.
  */
 
+use Drupal\field\Entity\FieldConfig;
 use Drupal\user\Entity\Role;
 
 /**
@@ -53,4 +54,100 @@ function _social_geolocation_set_permissions() {
       user_role_grant_permissions('sitemanager', ['set social geolocation settings']);
     }
   }
+}
+
+/**
+ * Create flexible_group geolocation field if module is enabled.
+ */
+function social_geolocation_update_8006(&$sandbox) {
+  // Install geolocation field for flexible group.
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('social_group_flexible_group')) {
+    $config_yaml = [
+      'langcode' => 'en',
+      'status' => TRUE,
+      'dependencies' => [
+        'config' => [
+          'field.storage.group.field_group_geolocation',
+          'group.type.flexible_group',
+        ],
+        'module' => [
+          'geolocation',
+          'social_group',
+          'social_group_flexible_group',
+        ],
+        'enforced' => [
+          'module' => [
+            'social_geolocation',
+          ],
+        ],
+      ],
+      'id' => 'group.flexible_group.field_group_geolocation',
+      'field_name' => 'field_group_geolocation',
+      'entity_type' => 'group',
+      'bundle' => 'flexible_group',
+      'label' => 'Geolocation',
+      'description' => '',
+      'required' => 'false',
+      'translatable' => 'false',
+      'default_value' => [],
+      'default_value_callback' => '',
+      'settings' => [],
+      'field_type' => 'geolocation',
+    ];
+
+    // Create the field configuration.
+    FieldConfig::create(
+          $config_yaml
+      )->save();
+  }
+
+}
+
+/**
+ * Create secret_group geolocation field if module is enabled.
+ */
+function social_geolocation_update_8007(&$sandbox) {
+  // Install geolocation field for flexible group.
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('social_group_flexible_group')) {
+    $config_yaml = [
+      'langcode' => 'en',
+      'status' => TRUE,
+      'dependencies' => [
+        'config' => [
+          'field.storage.group.field_group_geolocation',
+          'group.type.secret_group',
+        ],
+        'module' => [
+          'geolocation',
+          'social_group',
+          'social_group_secret_group',
+        ],
+        'enforced' => [
+          'module' => [
+            'social_geolocation',
+          ],
+        ],
+      ],
+      'id' => 'group.secret_group.field_group_geolocation',
+      'field_name' => 'field_group_geolocation',
+      'entity_type' => 'group',
+      'bundle' => 'secret_group',
+      'label' => 'Geolocation',
+      'description' => '',
+      'required' => 'false',
+      'translatable' => 'false',
+      'default_value' => [],
+      'default_value_callback' => '',
+      'settings' => [],
+      'field_type' => 'geolocation',
+    ];
+
+    // Create the field configuration.
+    FieldConfig::create(
+          $config_yaml
+      )->save();
+  }
+
 }


### PR DESCRIPTION
## Problem
Open Social also supports two other kinds of groups which can be found here: https://github.com/goalgorilla/open_social/tree/8.x-9.x/modules/social_features/social_group/modules

## Solution
Add field configurations in an optional folder.
Add an update hook to add these configurations on the existing website.

## Issue tracker
https://getopensocial.atlassian.net/browse/TB-4608
https://www.drupal.org/project/social_geolocation/issues/3154252

## How to test
- [ ] Create a flexible or secret group with address
- [ ] Check database for group geolocation field, they should have geolocation data for this entity ID added in step 1

## Release notes
Social geolocation now will support flexible and secret groups as well.
